### PR TITLE
Remove Tabnine plugin

### DIFF
--- a/lua/bilu/keymaps.lua
+++ b/lua/bilu/keymaps.lua
@@ -59,11 +59,3 @@ nnoremap("gd", ":Telescope lsp_definitions<CR>")
 nnoremap("<leader>t", ":ToggleTerm<CR>")
 tnoremap("<esc>", "<C-\\><C-n>")
 tnoremap("jk", "<C-\\><C-n>")
-
--- tabnine
--- nnoremap("<leader>q", ":TabnineChat<CR>")
--- xnoremap("<leader>q", ":<C-U>TabnineChat<CR>")
-
-api.nvim_set_keymap("x", "<leader>q", "", { noremap = true, callback = require("tabnine.chat").open })
-api.nvim_set_keymap("i", "<leader>q", "", { noremap = true, callback = require("tabnine.chat").open })
-api.nvim_set_keymap("n", "<leader>q", "", { noremap = true, callback = require("tabnine.chat").open })

--- a/lua/bilu/plugins.lua
+++ b/lua/bilu/plugins.lua
@@ -38,8 +38,6 @@ local M = require("packer").startup(function(use)
 
 	use("hashivim/vim-terraform")
 
-	use({ "~/Workspace/tabnine-nvim", run = "./dl_binaries.sh" })
-
 	use("nvim-telescope/telescope.nvim")
 
 	-- treeistter

--- a/lua/bilu/plugins/lualine.lua
+++ b/lua/bilu/plugins/lualine.lua
@@ -9,6 +9,6 @@ require("lualine").setup({
 	},
 	sections = {
 		lualine_c = { 'require("lsp-status").status()' },
-		lualine_x = { "tabnine" },
+		lualine_x = {},
 	},
 })

--- a/lua/bilu/plugins/tabnine.lua
+++ b/lua/bilu/plugins/tabnine.lua
@@ -1,9 +1,0 @@
-require("tabnine").setup({
-	debounce_ms = 800,
-	disable_auto_comment = true,
-	accept_keymap = "<Tab>",
-	suggestion_hl_group = "Comment",
-	suggestion_color = { gui = "#808080", cterm = 244 },
-	tabnine_enterprise_host = "https://dev.tabnine.io",
-	log_file_path = "/tmp/tabnine-nvim.log",
-})


### PR DESCRIPTION
Remove Tabnine plugin from the configuration.

* **Remove Tabnine plugin inclusion**
  - Remove the line that includes the `tabnine` plugin in `lua/bilu/plugins.lua`.

* **Remove Tabnine keymaps**
  - Remove the lines that map the `TabnineChat` command in `lua/bilu/keymaps.lua`.
  - Remove the lines that set keymaps for `tabnine.chat` in `lua/bilu/keymaps.lua`.

* **Update lualine configuration**
  - Remove the line that includes `tabnine` in the `lualine_x` section in `lua/bilu/plugins/lualine.lua`.

* **Delete Tabnine configuration file**
  - Delete `lua/bilu/plugins/tabnine.lua`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/amirbilu/nvim-config/pull/3?shareId=fd0228b7-145b-4180-a62c-1661b7d6c2b5).